### PR TITLE
Rephrase upload size limit message

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -28,7 +28,7 @@
  */
 const uploadLimit = size => t(
 	'browser_warning',
-	'Because you are using an outdated browser, your won\'t be able to upload files bigger than {maxsize}.',
+	'You are using an outdated browser and therefore won\'t be able to upload files larger than {maxsize}.',
 	{ maxsize: OC.Util.humanFileSize(size) }
 )
 


### PR DESCRIPTION
I believe the message reads better this way:
 * does not start with relative clause
 * use "larger" instead of "bigger"
 * removes typo "you[r]"